### PR TITLE
Fix Coolify 4.2.0+ compatibility: POST for state-changing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,25 @@
 
 <img src="graphics/CoolifyMCP.png" width="256" alt="Coolify MCP Logo" />
 
-A Model Context Protocol (MCP) server providing full coverage of the **Coolify v4.1.1** REST API. Manage applications, databases, services, servers, deployments, and more — all from any MCP-compatible AI client.
+A Model Context Protocol (MCP) server providing full coverage of the **Coolify v4.3.1** REST API. Manage applications, databases, services, servers, deployments, and more — all from any MCP-compatible AI client.
 
 <a href="https://glama.ai/mcp/servers/@wrediam/coolify-mcp-server">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@wrediam/coolify-mcp-server/badge" alt="Coolify Server MCP server" />
 </a>
 
-> **Compatibility:** Coolify v4.1.1+ (stable, non-beta). API base: `https://<your-coolify-instance>/api/v1`
+> **Compatibility:** Coolify v4.x. API base: `https://<your-coolify-instance>/api/v1`
+
+Coolify v4.2.0 made state-changing endpoints POST-only; the former GET routes now
+return `This endpoint has changed to a POST request.` This server issues POST for
+all of them. Lifecycle and deploy operations remain compatible with earlier v4.x
+releases, which accepted both methods. Three tools — `enable_api`, `disable_api`
+and `validate_server` — call endpoints that were GET-only before v4.2.0 and so
+require **Coolify v4.2.0 or newer**.
 
 ## Prerequisites
 
 - Node.js 18 or higher
-- A running Coolify v4.1.1+ instance
+- A running Coolify v4 instance (v4.2.0+ for the three tools noted above)
 - A Coolify API token (from **Security → API Tokens** in the dashboard)
 
 ## Installation
@@ -94,13 +101,16 @@ Set two environment variables:
 ### Applications
 - `list_applications`, `get_application`
 - `create_public_application`, `create_private_github_app_application`, `create_private_deploy_key_application`
-- `create_dockerfile_application`, `create_dockerimage_application`, `create_dockercompose_application`
+- `create_dockerfile_application`, `create_dockerimage_application`
 - `update_application`, `delete_application`
 - `start_application`, `stop_application`, `restart_application`
 - `get_application_logs`
 - `list_application_envs`, `create_application_env`, `update_application_env`, `bulk_update_application_envs`, `delete_application_env`
 - `list_application_storages`, `create_application_storage`, `delete_application_storage`
 - `list_application_scheduled_tasks`, `create_application_scheduled_task`, `delete_application_scheduled_task`
+
+> To create a resource from a raw Docker Compose file, use `create_service` with
+> `docker_compose_raw`. Coolify has no application-level compose creation endpoint.
 
 ### Databases
 - `list_databases`, `get_database`, `update_database`, `delete_database`

--- a/api-spec.md
+++ b/api-spec.md
@@ -1,6 +1,7 @@
 # Coolify API Reference
 
 > **Source:** [`openapi.yaml` on `v4.x` branch](https://raw.githubusercontent.com/coollabsio/coolify/v4.x/openapi.yaml)  
+> **Verified against:** [`routes/api.php` at `v4.3.1`](https://github.com/coollabsio/coolify/blob/v4.3.1/routes/api.php)  
 > **OpenAPI Version:** 3.1.0  
 > **API Version:** 0.1  
 > **Base URL:** `https://<your-coolify-instance>/api/v1`
@@ -52,8 +53,9 @@ Doc: https://coolify.io/docs/api-reference/authorization
 
 ---
 
-### `GET /enable`
+### `POST /enable`
 **operationId:** `enable-api`  
+**Method:** POST only since Coolify v4.2.0.  
 **Summary:** Enable API (root permissions only).  
 **Auth:** Bearer token required  
 **Response 200:** `{ "message": "API enabled." }`  
@@ -62,8 +64,9 @@ Doc: https://coolify.io/docs/api-reference/authorization
 
 ---
 
-### `GET /disable`
+### `POST /disable`
 **operationId:** `disable-api`  
+**Method:** POST only since Coolify v4.2.0.  
 **Summary:** Disable API (root permissions only).  
 **Auth:** Bearer token required  
 **Response 200:** `{ "message": "API disabled." }`  
@@ -158,15 +161,6 @@ Doc: https://coolify.io/docs/api-reference/authorization
 
 ---
 
-### `POST /applications/dockercompose`
-**operationId:** `create-dockercompose-application`  
-**Summary:** Create application from a Docker Compose file (no git).  
-**Required Body Fields:** `project_uuid`, `server_uuid`, `environment_name` or `environment_uuid`  
-**Response 201:** `{ "uuid": string }`  
-**Doc:** https://coolify.io/docs/api-reference/api/operations/create-dockercompose-application
-
----
-
 ### `GET /applications/{uuid}`
 **operationId:** `get-application-by-uuid`  
 **Summary:** Get application by UUID.  
@@ -206,29 +200,32 @@ Doc: https://coolify.io/docs/api-reference/authorization
 
 ---
 
-### `GET /applications/{uuid}/start`
+### `POST /applications/{uuid}/start`
 **operationId:** `start-application-by-uuid`  
-**Summary:** Start application. `POST` also accepted.  
+**Method:** POST only since Coolify v4.2.0.  
+**Summary:** Start application.  
 **Path Params:** `uuid`  
-**Query Params:** `force` (bool, default false), `instant_deploy` (bool, default false)  
+**Body Params:** `force` (bool, default false), `instant_deploy` (bool, default false)  
 **Response 200:** `{ "message": "Deployment request queued.", "deployment_uuid": string }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/start-application-by-uuid
 
 ---
 
-### `GET /applications/{uuid}/stop`
+### `POST /applications/{uuid}/stop`
 **operationId:** `stop-application-by-uuid`  
-**Summary:** Stop application. `POST` also accepted.  
+**Method:** POST only since Coolify v4.2.0.  
+**Summary:** Stop application.  
 **Path Params:** `uuid`  
-**Query Params:** `docker_cleanup` (bool, default true)  
+**Body Params:** `docker_cleanup` (bool, default true)  
 **Response 200:** `{ "message": "Application stopping request queued." }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/stop-application-by-uuid
 
 ---
 
-### `GET /applications/{uuid}/restart`
+### `POST /applications/{uuid}/restart`
 **operationId:** `restart-application-by-uuid`  
-**Summary:** Restart application. `POST` also accepted.  
+**Method:** POST only since Coolify v4.2.0.  
+**Summary:** Restart application.  
 **Path Params:** `uuid`  
 **Response 200:** `{ "message": "Restart request queued.", "deployment_uuid": string }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/restart-application-by-uuid
@@ -430,26 +427,29 @@ Doc: https://coolify.io/docs/api-reference/authorization
 
 ---
 
-### `GET /databases/{uuid}/start`
+### `POST /databases/{uuid}/start`
 **operationId:** `start-database-by-uuid`  
-**Summary:** Start database. `POST` also accepted.  
+**Method:** POST only since Coolify v4.2.0.  
+**Summary:** Start database.  
 **Response 200:** `{ "message": "Database starting request queued." }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/start-database-by-uuid
 
 ---
 
-### `GET /databases/{uuid}/stop`
+### `POST /databases/{uuid}/stop`
 **operationId:** `stop-database-by-uuid`  
-**Summary:** Stop database. `POST` also accepted.  
-**Query Params:** `docker_cleanup` (bool, default true)  
+**Method:** POST only since Coolify v4.2.0.  
+**Summary:** Stop database.  
+**Body Params:** `docker_cleanup` (bool, default true)  
 **Response 200:** `{ "message": "Database stopping request queued." }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/stop-database-by-uuid
 
 ---
 
-### `GET /databases/{uuid}/restart`
+### `POST /databases/{uuid}/restart`
 **operationId:** `restart-database-by-uuid`  
-**Summary:** Restart database. `POST` also accepted.  
+**Method:** POST only since Coolify v4.2.0.  
+**Summary:** Restart database.  
 **Response 200:** `{ "message": "Database restarting request queued." }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/restart-database-by-uuid
 
@@ -615,27 +615,30 @@ Doc: https://coolify.io/docs/api-reference/authorization
 
 ---
 
-### `GET /services/{uuid}/start`
+### `POST /services/{uuid}/start`
 **operationId:** `start-service-by-uuid`  
-**Summary:** Start service. `POST` also accepted.  
+**Method:** POST only since Coolify v4.2.0.  
+**Summary:** Start service.  
 **Response 200:** `{ "message": "Service starting request queued." }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/start-service-by-uuid
 
 ---
 
-### `GET /services/{uuid}/stop`
+### `POST /services/{uuid}/stop`
 **operationId:** `stop-service-by-uuid`  
-**Summary:** Stop service. `POST` also accepted.  
-**Query Params:** `docker_cleanup` (bool, default true)  
+**Method:** POST only since Coolify v4.2.0.  
+**Summary:** Stop service.  
+**Body Params:** `docker_cleanup` (bool, default true)  
 **Response 200:** `{ "message": "Service stopping request queued." }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/stop-service-by-uuid
 
 ---
 
-### `GET /services/{uuid}/restart`
+### `POST /services/{uuid}/restart`
 **operationId:** `restart-service-by-uuid`  
-**Summary:** Restart service. `POST` also accepted.  
-**Query Params:** `latest` (bool, default false — pull latest images)  
+**Method:** POST only since Coolify v4.2.0.  
+**Summary:** Restart service.  
+**Body Params:** `latest` (bool, default false — pull latest images)  
 **Response 200:** `{ "message": "Service restarting request queued." }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/restart-service-by-uuid
 
@@ -749,9 +752,12 @@ Doc: https://coolify.io/docs/api-reference/authorization
 
 ---
 
-### `GET /servers/{uuid}/validate`
+### `POST /servers/{uuid}/validate`
 **operationId:** `validate-server-by-uuid`  
+**Method:** POST only since Coolify v4.2.0.  
 **Summary:** Validate server by UUID.  
+**Path Params:** `uuid`  
+**Body Params:** `install` (bool, default false — also install Coolify prerequisites)  
 **Response 201:** `{ "message": "Validation started." }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/validate-server-by-uuid
 
@@ -941,10 +947,11 @@ Doc: https://coolify.io/docs/api-reference/authorization
 
 ---
 
-### `GET /deploy`
+### `POST /deploy`
 **operationId:** `deploy-by-tag-or-uuid`  
-**Summary:** Deploy by tag or UUID. `POST` also accepted with `uuid` and `tag` JSON body.  
-**Query Params:** `tag` (string, comma-separated), `uuid` (string, comma-separated), `force` (bool), `pr` (int — PR id), `pull_request_id` (int), `docker_tag` (string)  
+**Method:** POST only since Coolify v4.2.0.  
+**Summary:** Deploy by tag or UUID.  
+**Body Params:** `tag` (string, comma-separated), `uuid` (string, comma-separated), `force` (bool), `pr` (int — PR id), `pull_request_id` (int), `docker_tag` (string)  
 **Response 200:** `{ "deployments": [{ message, resource_uuid, deployment_uuid }] }`  
 **Doc:** https://coolify.io/docs/api-reference/api/operations/deploy-by-tag-or-uuid
 
@@ -970,9 +977,10 @@ Doc: https://coolify.io/docs/api-reference/authorization
 
 ---
 
-### `PATCH /security/keys`
+### `PATCH /security/keys/{uuid}`
 **operationId:** `update-private-key`  
 **Summary:** Update a private key.  
+**Path Params:** `uuid`  
 **Required Body:** `private_key`  
 **Optional Body:** `name`, `description`  
 **Response 201:** `{ "uuid": string }`  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coolify-mcp-server",
-  "version": "4.1.1",
+  "version": "4.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coolify-mcp-server",
-      "version": "4.1.1",
+      "version": "4.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coolify-mcp-server",
-  "version": "4.1.1",
-  "description": "MCP server for Coolify v4.1.1 API — full coverage of all endpoints",
+  "version": "4.3.1",
+  "description": "MCP server for Coolify v4.3.1 API — full coverage of all endpoints",
   "type": "module",
   "main": "build/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2055,7 +2055,7 @@ class CoolifyServer {
 
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    console.error('Coolify MCP Server v4.1.1 running on stdio');
+    console.error('Coolify MCP Server v4.3.1 running on stdio');
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ class CoolifyServer {
     this.server = new Server(
       {
         name: 'coolify-mcp-server',
-        version: '4.1.1',
+        version: '4.3.1',
       },
       {
         capabilities: {
@@ -67,7 +67,7 @@ class CoolifyServer {
         // ── General ──────────────────────────────────────────────────────────
         {
           name: 'get_version',
-          description: 'Get the Coolify version string (e.g. "v4.1.1").',
+          description: 'Get the Coolify version string (e.g. "4.3.1").',
           inputSchema: { type: 'object', properties: {}, required: [] }
         },
         {
@@ -77,12 +77,12 @@ class CoolifyServer {
         },
         {
           name: 'enable_api',
-          description: 'Enable the Coolify API. Requires root-level token.',
+          description: 'Enable the Coolify API. Requires root-level token and Coolify >= 4.2.0.',
           inputSchema: { type: 'object', properties: {}, required: [] }
         },
         {
           name: 'disable_api',
-          description: 'Disable the Coolify API. Requires root-level token.',
+          description: 'Disable the Coolify API. Requires root-level token and Coolify >= 4.2.0.',
           inputSchema: { type: 'object', properties: {}, required: [] }
         },
         {
@@ -203,10 +203,13 @@ class CoolifyServer {
         },
         {
           name: 'validate_server',
-          description: 'Validate server connectivity and configuration.',
+          description: 'Validate server connectivity and configuration. Requires Coolify >= 4.2.0.',
           inputSchema: {
             type: 'object',
-            properties: { uuid: { type: 'string', description: 'Server UUID.' } },
+            properties: {
+              uuid: { type: 'string', description: 'Server UUID.' },
+              install: { type: 'boolean', description: 'Also install Coolify prerequisites on the server.', default: false }
+            },
             required: ['uuid']
           }
         },
@@ -472,23 +475,6 @@ class CoolifyServer {
               instant_deploy: { type: 'boolean', default: false }
             },
             required: ['project_uuid', 'server_uuid', 'docker_registry_image_name', 'ports_exposes']
-          }
-        },
-        {
-          name: 'create_dockercompose_application',
-          description: 'Create an application from a Docker Compose file (no Git).',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              project_uuid: { type: 'string' },
-              server_uuid: { type: 'string' },
-              environment_name: { type: 'string' },
-              environment_uuid: { type: 'string' },
-              docker_compose_raw: { type: 'string', description: 'Raw Docker Compose YAML content.' },
-              name: { type: 'string' },
-              instant_deploy: { type: 'boolean', default: false }
-            },
-            required: ['project_uuid', 'server_uuid']
           }
         },
         {
@@ -1311,11 +1297,12 @@ class CoolifyServer {
           inputSchema: {
             type: 'object',
             properties: {
+              uuid: { type: 'string', description: 'Private key UUID.' },
               name: { type: 'string' },
               description: { type: 'string' },
               private_key: { type: 'string' }
             },
-            required: ['private_key']
+            required: ['uuid', 'private_key']
           }
         },
         {
@@ -1473,11 +1460,11 @@ class CoolifyServer {
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'enable_api': {
-            const r = await this.axiosInstance.get('/enable');
+            const r = await this.axiosInstance.post('/enable');
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'disable_api': {
-            const r = await this.axiosInstance.get('/disable');
+            const r = await this.axiosInstance.post('/disable');
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'enable_mcp': {
@@ -1540,7 +1527,8 @@ class CoolifyServer {
           }
           case 'validate_server': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
-            const r = await this.axiosInstance.get(`/servers/${args.uuid}/validate`);
+            const { uuid: vsuuid, ...validateBody } = args as Record<string, unknown>;
+            const r = await this.axiosInstance.post(`/servers/${vsuuid}/validate`, validateBody);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'get_server_resources': {
@@ -1639,10 +1627,6 @@ class CoolifyServer {
             const r = await this.axiosInstance.post('/applications/dockerimage', args);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
-          case 'create_dockercompose_application': {
-            const r = await this.axiosInstance.post('/applications/dockercompose', args);
-            return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
-          }
           case 'update_application': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
             const { uuid: auuid, ...appPatch } = args as Record<string, unknown>;
@@ -1657,19 +1641,19 @@ class CoolifyServer {
           }
           case 'start_application': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
-            const { uuid: sauuid, ...startParams } = args as Record<string, unknown>;
-            const r = await this.axiosInstance.get(`/applications/${sauuid}/start`, { params: startParams });
+            const { uuid: sauuid, ...startBody } = args as Record<string, unknown>;
+            const r = await this.axiosInstance.post(`/applications/${sauuid}/start`, startBody);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'stop_application': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
-            const { uuid: stauuid, ...stopParams } = args as Record<string, unknown>;
-            const r = await this.axiosInstance.get(`/applications/${stauuid}/stop`, { params: stopParams });
+            const { uuid: stauuid, ...stopBody } = args as Record<string, unknown>;
+            const r = await this.axiosInstance.post(`/applications/${stauuid}/stop`, stopBody);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'restart_application': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
-            const r = await this.axiosInstance.get(`/applications/${args.uuid}/restart`);
+            const r = await this.axiosInstance.post(`/applications/${args.uuid}/restart`);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'get_application_logs': {
@@ -1800,18 +1784,18 @@ class CoolifyServer {
           }
           case 'start_database': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
-            const r = await this.axiosInstance.get(`/databases/${args.uuid}/start`);
+            const r = await this.axiosInstance.post(`/databases/${args.uuid}/start`);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'stop_database': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
-            const { uuid: stopdbuuid, ...stopDbParams } = args as Record<string, unknown>;
-            const r = await this.axiosInstance.get(`/databases/${stopdbuuid}/stop`, { params: stopDbParams });
+            const { uuid: stopdbuuid, ...stopDbBody } = args as Record<string, unknown>;
+            const r = await this.axiosInstance.post(`/databases/${stopdbuuid}/stop`, stopDbBody);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'restart_database': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
-            const r = await this.axiosInstance.get(`/databases/${args.uuid}/restart`);
+            const r = await this.axiosInstance.post(`/databases/${args.uuid}/restart`);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           // Database Backups
@@ -1879,19 +1863,19 @@ class CoolifyServer {
           }
           case 'start_service': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
-            const r = await this.axiosInstance.get(`/services/${args.uuid}/start`);
+            const r = await this.axiosInstance.post(`/services/${args.uuid}/start`);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'stop_service': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
-            const { uuid: stsvuuid, ...stopSvParams } = args as Record<string, unknown>;
-            const r = await this.axiosInstance.get(`/services/${stsvuuid}/stop`, { params: stopSvParams });
+            const { uuid: stsvuuid, ...stopSvBody } = args as Record<string, unknown>;
+            const r = await this.axiosInstance.post(`/services/${stsvuuid}/stop`, stopSvBody);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'restart_service': {
             if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
-            const { uuid: rsvuuid, ...restartSvParams } = args as Record<string, unknown>;
-            const r = await this.axiosInstance.get(`/services/${rsvuuid}/restart`, { params: restartSvParams });
+            const { uuid: rsvuuid, ...restartSvBody } = args as Record<string, unknown>;
+            const r = await this.axiosInstance.post(`/services/${rsvuuid}/restart`, restartSvBody);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           // Service Envs
@@ -1953,7 +1937,7 @@ class CoolifyServer {
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'deploy_by_tag_or_uuid': {
-            const r = await this.axiosInstance.get('/deploy', { params: args });
+            const r = await this.axiosInstance.post('/deploy', args);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
 
@@ -1972,7 +1956,9 @@ class CoolifyServer {
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'update_private_key': {
-            const r = await this.axiosInstance.patch('/security/keys', args);
+            if (!args.uuid) throw new McpError(ErrorCode.InvalidParams, 'uuid is required');
+            const { uuid: pkuuid, ...keyPatch } = args as Record<string, unknown>;
+            const r = await this.axiosInstance.patch(`/security/keys/${pkuuid}`, keyPatch);
             return { content: [{ type: 'text', text: JSON.stringify(r.data, null, 2) }] };
           }
           case 'delete_private_key': {


### PR DESCRIPTION
Coolify 4.2.0 made state-changing API endpoints POST-only. The former GET routes
still resolve but dispatch to `OtherController::post_required`, which returns
`This endpoint has changed to a POST request.`, so every lifecycle and deploy
tool in this server is broken against Coolify >= 4.2.0.

## Changes

**13 call sites switched from GET to POST**, with parameters moved from the
query string into the JSON body:

```
/enable, /disable
/servers/{uuid}/validate
/applications/{uuid}/{start,stop,restart}
/databases/{uuid}/{start,stop,restart}
/services/{uuid}/{start,stop,restart}
/deploy
```

I derived that set from the `post_required` stubs in `routes/api.php` at
`v4.3.1` rather than enumerating it by hand, so it covers every endpoint Coolify
has deprecated, not just the obvious lifecycle ones. Existing parameter names
already matched 4.3.1, so nothing needed renaming; the handlers read them via
Laravel `$request->input()`/`boolean()`, which accepts a JSON body.

**Two further defects**, found by diffing the method and path of all 111 axios
calls against `routes/api.php`. Both are unrelated to 4.2.0 and both come from
`api-spec.md`:

- `update_private_key` called `PATCH /security/keys`; the route is
  `PATCH /security/keys/{uuid}`. The tool schema had no `uuid` field at all, so
  the tool could never have worked. Fixed, and `uuid` added to the schema.
- `create_dockercompose_application` called `POST /applications/dockercompose`,
  which has never existed in `routes/api.php` and has no controller method.
  Removed — raw Compose resources are created with `create_service` and
  `docker_compose_raw`.

**Also:**

- Added the `install` parameter that `validate_server`'s handler reads.
- Corrected `api-spec.md`, which documented all 13 endpoints as GET and was the
  source of both defects above.
- Bumped the version to 4.3.1 to match the API level, following the existing
  convention of tracking the Coolify version. Happy to change this if you'd
  rather it tracked the package separately.

## Compatibility

The 10 lifecycle and deploy routes were registered as
`Route::match(['get','post'], ...)` back to `v4.0.0-beta.397`, so POST works on
every Coolify 4.x — no version detection or fallback needed.

`/enable`, `/disable` and `/servers/{uuid}/validate` were GET-only before 4.2.0,
so those three tools now require **Coolify >= 4.2.0**. This is noted in the
README and in the tool descriptions. I did not add a GET fallback for them:
Coolify answers these with 404 rather than 405, which is indistinguishable from
a genuine "not found", so a fallback would mask real errors.

## Unrelated: #7

While auditing I looked at #7 (List deployments is empty) — it is not a bug and
this PR does not change it. `DeployController::deployments` filters to
`in_progress` and `queued` only, so an empty array is correct whenever nothing
is actively deploying. `list_deployments_by_application`
(`GET /deployments/applications/{uuid}`) is the one that returns history.

## Breaking change

`create_dockercompose_application` is removed, since the endpoint it called does
not exist.

## Testing

Against a live Coolify 4.3.1 instance, driving the built server over stdio:

- Application lifecycle end to end on a throwaway `traefik/whoami` app —
  `start_application` (with `force` and `instant_deploy` in the body),
  `restart_application`, `stop_application` (with `docker_cleanup`) — all
  returned queued deployments.
- Service lifecycle end to end on a throwaway Compose service —
  `start_service`, `restart_service` (with `latest`), `stop_service`,
  and `deploy_by_tag_or_uuid`.
- `start/stop/restart_database`, `validate_server` and `update_private_key`
  verified by route resolution: they now return the handler's "not found"
  rather than the deprecation message.
- All scratch resources deleted afterwards.

Statically, all 110 remaining axios calls now match a route in `routes/api.php`
at `v4.3.1`, with none hitting a deprecated GET stub — down from 15 mismatches
before this change.

I did not exercise `enable_api`/`disable_api` against a live instance, since
disabling the API on a working instance is not something to test casually; they
are covered by the static check.
